### PR TITLE
Add automatic posting date and validation for Weekly Checkin

### DIFF
--- a/pulsecheck/pulse_check/doctype/weekly_checkin/test_weekly_checkin.py
+++ b/pulsecheck/pulse_check/doctype/weekly_checkin/test_weekly_checkin.py
@@ -1,9 +1,13 @@
 # Copyright (c) 2025, Prashant Agrawal and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests.utils import FrappeTestCase
 
 
 class TestWeeklyCheckin(FrappeTestCase):
-	pass
+    def test_posting_date_auto_populated(self):
+        weekly_checkin = frappe.new_doc("Weekly Checkin")
+        weekly_checkin.insert()
+
+        self.assertEqual(weekly_checkin.posting_date, frappe.utils.today())

--- a/pulsecheck/pulse_check/doctype/weekly_checkin/weekly_checkin.py
+++ b/pulsecheck/pulse_check/doctype/weekly_checkin/weekly_checkin.py
@@ -1,9 +1,37 @@
-# Copyright (c) 2025, Prashant Agrawal and contributors
-# For license information, please see license.txt
+"""Server-side logic for the Weekly Checkin DocType."""
 
-# import frappe
+import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
 class WeeklyCheckin(Document):
-	pass
+    """Weekly progress check-in document."""
+
+    def before_insert(self):
+        """Populate posting date when the document is first created."""
+        if not self.posting_date:
+            self.posting_date = frappe.utils.today()
+
+        self._validate_progress_range()
+
+    def validate(self):
+        """Run document level validations prior to saving."""
+        self._validate_progress_range()
+
+    def _validate_progress_range(self):
+        """Ensure progress related values stay within a 0-100 range."""
+        for fieldname in ("progress_reported", "progress"):
+            value = getattr(self, fieldname, None)
+            if value in (None, ""):
+                continue
+
+            try:
+                numeric_value = float(value)
+            except (TypeError, ValueError):
+                label = fieldname.replace("_", " ").title()
+                frappe.throw(_("{0} must be a number between 0 and 100.").format(label))
+
+            if not 0 <= numeric_value <= 100:
+                label = fieldname.replace("_", " ").title()
+                frappe.throw(_("{0} must be between 0 and 100.").format(label))


### PR DESCRIPTION
## Summary
- populate the Weekly Checkin posting date automatically on insert
- add validation to ensure progress values remain within the 0–100 range
- cover the posting date behavior with a unit test

## Testing
- pytest pulsecheck/pulse_check/doctype/weekly_checkin/test_weekly_checkin.py *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_68d7c8e99c50832284ddcec634623f39