### PR TITLE
Rename Pulse Check Setting DocType to PulseCheck Settings

### DIFF
--- a/pulsecheck/modules.txt
+++ b/pulsecheck/modules.txt
@@ -1,1 +1,2 @@
 Pulse Check
+PulseCheck Settings

--- a/pulsecheck/patches.txt
+++ b/pulsecheck/patches.txt
@@ -4,3 +4,4 @@
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
+pulsecheck.patches.post_model_sync.rename_pulse_check_setting

--- a/pulsecheck/patches/post_model_sync/rename_pulse_check_setting.py
+++ b/pulsecheck/patches/post_model_sync/rename_pulse_check_setting.py
@@ -1,0 +1,14 @@
+import frappe
+
+
+def execute():
+    if not frappe.db.exists("DocType", "Pulse Check Setting"):
+        return
+
+    frappe.rename_doc(
+        "DocType",
+        "Pulse Check Setting",
+        "PulseCheck Settings",
+        force=True,
+        merge=False,
+    )

--- a/pulsecheck/pulse_check/doctype/pulsecheck_settings/pulsecheck_settings.js
+++ b/pulsecheck/pulse_check/doctype/pulsecheck_settings/pulsecheck_settings.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2025, Prashant Agrawal and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Pulse Check Setting", {
+// frappe.ui.form.on("PulseCheck Settings", {
 // 	refresh(frm) {
 
 // 	},

--- a/pulsecheck/pulse_check/doctype/pulsecheck_settings/pulsecheck_settings.json
+++ b/pulsecheck/pulse_check/doctype/pulsecheck_settings/pulsecheck_settings.json
@@ -62,8 +62,8 @@
  "links": [],
  "modified": "2025-09-27 16:46:38.019696",
  "modified_by": "Administrator",
- "module": "Pulse Check",
- "name": "Pulse Check Setting",
+ "module": "PulseCheck Settings",
+ "name": "PulseCheck Settings",
  "owner": "Administrator",
  "permissions": [
   {

--- a/pulsecheck/pulse_check/doctype/pulsecheck_settings/pulsecheck_settings.py
+++ b/pulsecheck/pulse_check/doctype/pulsecheck_settings/pulsecheck_settings.py
@@ -5,5 +5,5 @@
 from frappe.model.document import Document
 
 
-class PulseCheckSetting(Document):
-	pass
+class PulsecheckSettings(Document):
+pass

--- a/pulsecheck/pulse_check/doctype/pulsecheck_settings/test_pulsecheck_settings.py
+++ b/pulsecheck/pulse_check/doctype/pulsecheck_settings/test_pulsecheck_settings.py
@@ -5,5 +5,5 @@
 from frappe.tests.utils import FrappeTestCase
 
 
-class TestPulseCheckSetting(FrappeTestCase):
-	pass
+class TestPulsecheckSettings(FrappeTestCase):
+pass


### PR DESCRIPTION
## Summary
- rename the Pulse Check Setting DocType files and metadata to PulseCheck Settings
- update the controller/test class names to match the new DocType naming
- add a post-model-sync patch to migrate existing DocType records and register the new module entry

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7c8f608c08322aab3d561f6cc01fb