### PR TITLE
Update Weekly Checkin posting date handling

### DIFF
--- a/pulsecheck/pulse_check/doctype/weekly_checkin/test_weekly_checkin.py
+++ b/pulsecheck/pulse_check/doctype/weekly_checkin/test_weekly_checkin.py
@@ -8,6 +8,12 @@ from frappe.tests.utils import FrappeTestCase
 class TestWeeklyCheckin(FrappeTestCase):
     def test_posting_date_auto_populated(self):
         weekly_checkin = frappe.new_doc("Weekly Checkin")
+        weekly_checkin.flags.ignore_mandatory = True
+        weekly_checkin.flags.ignore_links = True
+
         weekly_checkin.insert()
+        self.assertFalse(weekly_checkin.posting_date)
+
+        weekly_checkin.submit()
 
         self.assertEqual(weekly_checkin.posting_date, frappe.utils.today())

--- a/pulsecheck/pulse_check/doctype/weekly_checkin/weekly_checkin.js
+++ b/pulsecheck/pulse_check/doctype/weekly_checkin/weekly_checkin.js
@@ -1,8 +1,7 @@
-// Copyright (c) 2025, Prashant Agrawal and contributors
-// For license information, please see license.txt
-
-// frappe.ui.form.on("Weekly Checkin", {
-// 	refresh(frm) {
-
-// 	},
-// });
+frappe.ui.form.on("Weekly Checkin", {
+    refresh(frm) {
+        if (frm.is_new() && !frm.doc.posting_date) {
+            frm.set_value("posting_date", frappe.datetime.get_today());
+        }
+    },
+});

--- a/pulsecheck/pulse_check/doctype/weekly_checkin/weekly_checkin.py
+++ b/pulsecheck/pulse_check/doctype/weekly_checkin/weekly_checkin.py
@@ -8,16 +8,13 @@ from frappe.model.document import Document
 class WeeklyCheckin(Document):
     """Weekly progress check-in document."""
 
-    def before_insert(self):
-        """Populate posting date when the document is first created."""
-        if not self.posting_date:
-            self.posting_date = frappe.utils.today()
-
-        self._validate_progress_range()
-
     def validate(self):
         """Run document level validations prior to saving."""
         self._validate_progress_range()
+
+    def before_submit(self):
+        """Stamp the posting date just before submission."""
+        self.posting_date = frappe.utils.today()
 
     def _validate_progress_range(self):
         """Ensure progress related values stay within a 0-100 range."""


### PR DESCRIPTION
## Summary
- stamp the Weekly Checkin posting date during submission so it reflects the submission day
- add a client script to show a default posting date on new Weekly Checkin drafts
- update the Weekly Checkin test to submit the document and verify the posting date

## Testing
- not run (bench-based frappe test environment unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68d7cc32fb688322bb11ea43aace1880