### PR TITLE
Use decrypted Slack bot token when available

### DIFF
--- a/pulsecheck/pulse_check/notifications.py
+++ b/pulsecheck/pulse_check/notifications.py
@@ -147,10 +147,27 @@ def should_run_now(settings, now: datetime | None = None, window_minutes: int = 
 
 
 def get_slack_token(settings) -> str | None:
-    token = getattr(settings, "slack_bot_token", None)
-    if token:
-        token = token.strip()
-    return token or None
+    if not settings:
+        return None
+
+    def _clean(value) -> str | None:
+        if isinstance(value, str):
+            value = value.strip()
+        elif value is not None:
+            value = str(value).strip()
+        return value or None
+
+    get_password = getattr(settings, "get_password", None)
+    if callable(get_password):
+        try:
+            token = _clean(get_password("slack_bot_token"))
+        except Exception:
+            token = None
+        else:
+            if token:
+                return token
+
+    return _clean(getattr(settings, "slack_bot_token", None))
 
 
 def _get_cache():

--- a/pulsecheck/pulse_check/test_jobs.py
+++ b/pulsecheck/pulse_check/test_jobs.py
@@ -201,3 +201,31 @@ def test_send_weekly_digest_handles_missing_checkins(monkeypatch):
 
     sent = digests.send_weekly_digest(now=datetime(2024, 1, 8, 10, 5))
     assert sent is False
+
+
+def test_get_slack_token_uses_decrypted_value():
+    calls: list[str] = []
+
+    class Settings(SimpleNamespace):
+        def get_password(self, key: str) -> str:
+            calls.append(key)
+            return "  decrypted-token  "
+
+    settings = Settings(slack_bot_token="should-not-be-used")
+
+    token = notifications.get_slack_token(settings)
+
+    assert token == "decrypted-token"
+    assert calls == ["slack_bot_token"]
+
+
+def test_get_slack_token_falls_back_on_error():
+    class Settings(SimpleNamespace):
+        def get_password(self, key: str) -> str:
+            raise RuntimeError("boom")
+
+    settings = Settings(slack_bot_token="  fallback-token  ")
+
+    token = notifications.get_slack_token(settings)
+
+    assert token == "fallback-token"


### PR DESCRIPTION
## Summary
- fetch the Slack bot token via `get_password` so decrypted credentials are used when available
- fall back to the stored attribute when decryption fails or is unavailable
- extend the job tests to cover the decrypted-token and fallback paths

## Testing
- `pytest pulsecheck/pulse_check/test_jobs.py`


------
https://chatgpt.com/codex/tasks/task_e_68d80fb09b5c832296e66575e1ad2b5c