### PR TITLE
Route weekly digests through managers

### DIFF
--- a/pulsecheck/pulse_check/digests.py
+++ b/pulsecheck/pulse_check/digests.py
@@ -41,36 +41,72 @@ def send_weekly_digest(now: datetime | None = None) -> bool:
         logger.warning("Slack bot token is missing; digest cannot be delivered.")
         return False
 
-    recipients = notifications.get_slack_recipients()
-    if not recipients:
-        logger.info("No Slack recipients were found; nothing to send.")
-        return False
-
     week_start, week_end = notifications.get_week_bounds(now, offset_weeks=-1)
     checkins = _fetch_weekly_checkins(week_start, week_end)
 
-    digest_message = _compose_digest_message(checkins, week_start, week_end)
-    if not digest_message:
+    if not checkins:
+        logger.info(
+            "No Weekly Check-in submissions found for the %s - %s window; skipping digest.",
+            week_start,
+            week_end,
+        )
+        return False
+
+    employees_by_id, employees_by_display = _build_employee_directory()
+    if not employees_by_id:
+        logger.info("No employees with manager relationships were found; skipping digest.")
+        return False
+
+    manager_map, unassigned = _group_checkins_by_manager(
+        checkins, employees_by_id, employees_by_display
+    )
+    if not manager_map:
+        logger.info("No managers with Slack identifiers were found for digest delivery.")
         return False
 
     messages_sent = 0
-    for recipient in recipients:
+    for manager_name in sorted(
+        manager_map,
+        key=lambda name: (employees_by_id.get(name, {}).get("employee_name") or name or "").lower(),
+    ):
+        manager = employees_by_id.get(manager_name)
+        if not manager:
+            continue
+        slack_id = (manager.get("slack_user_id") or "").strip()
+        if not slack_id:
+            continue
+
+        digest_message = _compose_manager_digest(
+            manager,
+            manager_map[manager_name],
+            week_start,
+            week_end,
+        )
+        if not digest_message:
+            continue
+
         try:
             notifications.post_to_slack(
                 token,
                 {
-                    "channel": recipient.get("slack_user_id"),
+                    "channel": slack_id,
                     "text": digest_message,
                 },
             )
         except notifications.SlackDeliveryError as exc:
-            logger.exception("Failed to send digest to %s: %s", recipient.get("slack_user_id"), exc)
+            logger.exception("Failed to send digest to %s: %s", slack_id, exc)
             continue
 
         messages_sent += 1
 
     if messages_sent:
         notifications.mark_executed(_CACHE_KEY, now=now)
+
+    if unassigned:
+        logger.info(
+            "Skipped %s Weekly Check-in entries without a manager Slack recipient.",
+            len(unassigned),
+        )
 
     return bool(messages_sent)
 
@@ -115,31 +151,162 @@ def _weekly_checkin_table_exists() -> bool:
     return False
 
 
-def _compose_digest_message(checkins: list[dict], week_start, week_end) -> str:
-    if not checkins:
-        logger.info(
-            "No Weekly Check-in submissions found for the %s - %s window; skipping digest.",
-            week_start,
-            week_end,
-        )
-        return ""
+def _build_employee_directory() -> tuple[dict[str, dict], dict[str, dict]]:
+    """Return employee directory data structures for lookup."""
 
-    header = f"*Pulse Check digest* for {week_start:%b %d} - {week_end:%b %d}"
-    lines = [header, ""]
+    employees = notifications.get_employee_directory(
+        extra_fields=list(_MANAGER_FIELDS)
+    )
+
+    if not employees:
+        return {}, {}
+
+    by_id: dict[str, dict] = {}
+    by_display: dict[str, dict] = {}
+    for employee in employees:
+        name = employee.get("name")
+        if not name:
+            continue
+        by_id[name] = employee
+        display_key = _normalize(employee.get("employee_name") or name)
+        if display_key and display_key not in by_display:
+            by_display[display_key] = employee
+
+    return by_id, by_display
+
+
+def _group_checkins_by_manager(
+    checkins: list[dict],
+    employees_by_id: dict[str, dict],
+    employees_by_display: dict[str, dict],
+) -> tuple[dict[str, list[tuple[dict, dict]]], list[tuple[dict | None, dict]]]:
+    """Group Weekly Check-ins by the Slack-enabled managers responsible for them."""
+
+    manager_map: dict[str, list[tuple[dict, dict]]] = {}
+    unassigned: list[tuple[dict | None, dict]] = []
 
     for checkin in checkins:
-        employee_name = checkin.get("employee_name") or checkin.get("employee") or "Unknown employee"
+        employee = _resolve_employee(checkin, employees_by_id, employees_by_display)
+        if not employee:
+            unassigned.append((None, checkin))
+            continue
+
+        managers = _resolve_managers(employee, employees_by_id, employees_by_display)
+        delivered = False
+
+        for manager in managers:
+            slack_id = (manager.get("slack_user_id") or "").strip()
+            manager_name = manager.get("name")
+            if not slack_id or not manager_name:
+                continue
+            manager_map.setdefault(manager_name, []).append((employee, checkin))
+            delivered = True
+
+        if not delivered:
+            unassigned.append((employee, checkin))
+
+    return manager_map, unassigned
+
+
+def _resolve_employee(
+    checkin: dict,
+    employees_by_id: dict[str, dict],
+    employees_by_display: dict[str, dict],
+) -> dict | None:
+    employee_id = (checkin.get("employee") or "").strip()
+    if employee_id:
+        employee = employees_by_id.get(employee_id)
+        if employee:
+            return employee
+
+    display_key = _normalize(checkin.get("employee_name"))
+    if display_key:
+        return employees_by_display.get(display_key)
+
+    return None
+
+
+_MANAGER_FIELDS = ("reports_to", "leave_approver")
+
+
+def _resolve_managers(
+    employee: dict,
+    employees_by_id: dict[str, dict],
+    employees_by_display: dict[str, dict],
+) -> list[dict]:
+    manager_entries: list[dict] = []
+    seen: set[str] = set()
+
+    for field in _MANAGER_FIELDS:
+        reference = employee.get(field)
+        if isinstance(reference, str):
+            reference = reference.strip()
+        if not reference:
+            continue
+
+        manager = employees_by_id.get(reference)
+        if not manager:
+            manager = employees_by_display.get(_normalize(reference))
+        if not manager:
+            continue
+
+        manager_name = manager.get("name")
+        if not manager_name or manager_name == employee.get("name"):
+            continue
+
+        if manager_name in seen:
+            continue
+
+        seen.add(manager_name)
+        manager_entries.append(manager)
+
+    return manager_entries
+
+
+def _compose_manager_digest(
+    manager: dict,
+    entries: list[tuple[dict, dict]],
+    week_start,
+    week_end,
+) -> str:
+    if not entries:
+        return ""
+
+    manager_display = manager.get("employee_name") or manager.get("name") or "your team"
+    header = f"*Pulse Check digest* for {week_start:%b %d} - {week_end:%b %d}"
+    intro = f"Updates for your team, {manager_display}:"
+
+    lines = [header, intro, ""]
+
+    for employee, checkin in sorted(
+        entries,
+        key=lambda pair: _normalize(
+            pair[0].get("employee_name") or pair[0].get("name") or pair[1].get("employee_name")
+        ),
+    ):
+        employee_display = (
+            checkin.get("employee_name")
+            or employee.get("employee_name")
+            or employee.get("name")
+            or "Unknown employee"
+        )
         goal = checkin.get("goal") or "No goal linked"
         progress = checkin.get("progress_reported")
-        progress_fragment = f"{int(progress)}% complete" if progress not in (None, "") else "Progress not reported"
+        progress_fragment = (
+            f"{int(progress)}% complete" if progress not in (None, "") else "Progress not reported"
+        )
         confidence = checkin.get("confidence")
         if confidence:
             progress_fragment = f"{progress_fragment} · {confidence}"
 
-        lines.append(f"• *{employee_name}* - {goal}: {progress_fragment}")
+        lines.append(f"• *{employee_display}* - {goal}: {progress_fragment}")
 
         blockers = (checkin.get("blockers") or "").strip()
         if blockers:
-            lines.append(f"  Blockers: {blockers}")
+            lines.append(f"  ⚠️ *Blockers:* {blockers}")
 
     return "\n".join(lines)
+
+
+def _normalize(value: str | None) -> str:
+    return (value or "").strip().lower()

--- a/pulsecheck/pulse_check/notifications.py
+++ b/pulsecheck/pulse_check/notifications.py
@@ -20,6 +20,7 @@ __all__ = [
     "already_executed",
     "extract_schedule",
     "get_logger",
+    "get_employee_directory",
     "get_settings",
     "get_slack_recipients",
     "get_slack_token",
@@ -223,36 +224,28 @@ def _employee_table_exists() -> bool:
     return False
 
 
-def _employee_has_slack_field() -> bool:
+def _employee_has_field(field: str) -> bool:
     db = getattr(frappe, "db", None)
     has_column = getattr(db, "has_column", None)
     if callable(has_column):
         try:
-            return bool(has_column("Employee", "slack_user_id"))
+            return bool(has_column("Employee", field))
         except Exception:  # pragma: no cover - rely on fallback
             return False
     return False
 
 
+def _employee_has_slack_field() -> bool:
+    return _employee_has_field("slack_user_id")
+
+
 def get_slack_recipients() -> list[dict]:
     """Return active employees that have a Slack user identifier configured."""
 
-    if not _employee_table_exists() or not _employee_has_slack_field():
-        return []
-
-    try:
-        employees = frappe.get_all(  # type: ignore[call-arg]
-            "Employee",
-            filters={"status": "Active", "slack_user_id": ["!=", ""]},
-            fields=["name", "employee_name", "slack_user_id"],
-            order_by="employee_name asc",
-        )
-    except Exception:  # pragma: no cover - frappe provides richer errors
-        logger.warning("Unable to load Slack recipients from Employee records.")
-        return []
+    directory = get_employee_directory(require_slack=True)
 
     recipients = []
-    for employee in employees:
+    for employee in directory:
         slack_id = (employee.get("slack_user_id") or "").strip()
         if not slack_id:
             continue
@@ -265,6 +258,56 @@ def get_slack_recipients() -> list[dict]:
         )
 
     return recipients
+
+
+def get_employee_directory(
+    *, extra_fields: list[str] | None = None, require_slack: bool = False
+) -> list[dict]:
+    """Return active employees with optional extra fields.
+
+    When ``require_slack`` is True the result only includes employees that have a
+    ``slack_user_id`` configured.
+    """
+
+    if not _employee_table_exists():
+        return []
+
+    fields: set[str] = {"name", "employee_name"}
+
+    if require_slack:
+        if not _employee_has_slack_field():
+            return []
+        fields.add("slack_user_id")
+    elif _employee_has_slack_field():
+        fields.add("slack_user_id")
+
+    if extra_fields:
+        for field in extra_fields:
+            if _employee_has_field(field):
+                fields.add(field)
+
+    try:
+        employees = frappe.get_all(  # type: ignore[call-arg]
+            "Employee",
+            filters={"status": "Active"},
+            fields=sorted(fields),
+            order_by="employee_name asc",
+        )
+    except Exception:  # pragma: no cover - frappe provides richer errors
+        logger.warning("Unable to load Employee directory for Slack notifications.")
+        return []
+
+    cleaned: list[dict] = []
+    for employee in employees:
+        entry = dict(employee)
+        if "slack_user_id" in entry:
+            entry["slack_user_id"] = (entry.get("slack_user_id") or "").strip()
+        cleaned.append(entry)
+
+    if require_slack:
+        cleaned = [entry for entry in cleaned if entry.get("slack_user_id")]
+
+    return cleaned
 
 
 def get_week_bounds(now: datetime | None = None, *, offset_weeks: int = 0) -> tuple[date, date]:

--- a/pulsecheck/pulse_check/test_jobs.py
+++ b/pulsecheck/pulse_check/test_jobs.py
@@ -101,6 +101,8 @@ def _basic_settings(**overrides) -> SimpleNamespace:
 def _enable_employee_directory():
     _TABLES.add("tabEmployee")
     _COLUMNS.add(("Employee", "slack_user_id"))
+    _COLUMNS.add(("Employee", "reports_to"))
+    _COLUMNS.add(("Employee", "leave_approver"))
 
 
 def _enable_checkins_table():
@@ -126,7 +128,7 @@ def test_send_weekly_prompts_respects_window_with_timezone(monkeypatch):
     global _FAKE_SETTINGS
     _FAKE_SETTINGS = _basic_settings()
     _enable_employee_directory()
-    _FAKE_EMPLOYEES.append({"employee_name": "Ada", "slack_user_id": "U01"})
+    _FAKE_EMPLOYEES.append({"name": "EMP-ADA", "employee_name": "Ada", "slack_user_id": "U01"})
 
     payloads: list[dict] = []
 
@@ -162,7 +164,7 @@ def test_send_weekly_prompts_skips_when_disabled(monkeypatch):
     global _FAKE_SETTINGS
     _FAKE_SETTINGS = _basic_settings(enable_weekly_prompts=0)
     _enable_employee_directory()
-    _FAKE_EMPLOYEES.append({"employee_name": "Ada", "slack_user_id": "U01"})
+    _FAKE_EMPLOYEES.append({"name": "EMP-ADA", "employee_name": "Ada", "slack_user_id": "U01"})
 
     called = []
     monkeypatch.setattr(notifications, "post_to_slack", lambda *args, **kwargs: called.append((args, kwargs)))
@@ -176,7 +178,7 @@ def test_send_weekly_prompts_requires_token(monkeypatch):
     global _FAKE_SETTINGS
     _FAKE_SETTINGS = _basic_settings(slack_bot_token="   ")
     _enable_employee_directory()
-    _FAKE_EMPLOYEES.append({"employee_name": "Ada", "slack_user_id": "U01"})
+    _FAKE_EMPLOYEES.append({"name": "EMP-ADA", "employee_name": "Ada", "slack_user_id": "U01"})
 
     called = []
     monkeypatch.setattr(notifications, "post_to_slack", lambda *args, **kwargs: called.append((args, kwargs)))
@@ -190,7 +192,7 @@ def test_send_weekly_prompts_marks_execution(monkeypatch):
     global _FAKE_SETTINGS
     _FAKE_SETTINGS = _basic_settings()
     _enable_employee_directory()
-    _FAKE_EMPLOYEES.append({"employee_name": "Ada", "slack_user_id": "U01"})
+    _FAKE_EMPLOYEES.append({"name": "EMP-ADA", "employee_name": "Ada", "slack_user_id": "U01"})
 
     monkeypatch.setattr(notifications, "post_to_slack", lambda *args, **kwargs: None)
 
@@ -205,7 +207,7 @@ def test_send_weekly_prompts_skips_outside_window_with_timezone(monkeypatch):
     global _FAKE_SETTINGS
     _FAKE_SETTINGS = _basic_settings()
     _enable_employee_directory()
-    _FAKE_EMPLOYEES.append({"employee_name": "Ada", "slack_user_id": "U01"})
+    _FAKE_EMPLOYEES.append({"name": "EMP-ADA", "employee_name": "Ada", "slack_user_id": "U01"})
 
     called = []
     monkeypatch.setattr(notifications, "post_to_slack", lambda *args, **kwargs: called.append((args, kwargs)))
@@ -220,15 +222,37 @@ def test_send_weekly_digest_summarises_checkins(monkeypatch):
     _FAKE_SETTINGS = _basic_settings()
     _enable_employee_directory()
     _enable_checkins_table()
-    _FAKE_EMPLOYEES.append({"employee_name": "Ada", "slack_user_id": "U01"})
-    _FAKE_CHECKINS.append(
-        {
-            "employee_name": "Ada Lovelace",
-            "goal": "Grow pipeline",
-            "progress_reported": 80,
-            "confidence": "On Track",
-            "blockers": "None",
-        }
+    _FAKE_EMPLOYEES.extend(
+        [
+            {"name": "EMP-MGR", "employee_name": "Grace Manager", "slack_user_id": "UMGR"},
+            {"name": "EMP-ADA", "employee_name": "Ada Lovelace", "reports_to": "EMP-MGR"},
+            {
+                "name": "EMP-BOB",
+                "employee_name": "Bob Babbage",
+                "reports_to": "EMP-MGR",
+                "leave_approver": "Grace Manager",
+            },
+        ]
+    )
+    _FAKE_CHECKINS.extend(
+        [
+            {
+                "employee": "EMP-ADA",
+                "employee_name": "Ada Lovelace",
+                "goal": "Grow pipeline",
+                "progress_reported": 80,
+                "confidence": "On Track",
+                "blockers": "Need approvals",
+            },
+            {
+                "employee": "EMP-BOB",
+                "employee_name": "Bob Babbage",
+                "goal": "Improve retention",
+                "progress_reported": 40,
+                "confidence": "At Risk",
+                "blockers": "",
+            },
+        ]
     )
 
     payloads: list[dict] = []
@@ -241,9 +265,14 @@ def test_send_weekly_digest_summarises_checkins(monkeypatch):
     sent = digests.send_weekly_digest(now=datetime(2024, 1, 8, 10, 5, tzinfo=timezone.utc))
 
     assert sent is True
-    assert payloads, "Expected a digest payload to be sent"
-    assert "Pulse Check digest" in payloads[0]["text"]
-    assert "Ada Lovelace" in payloads[0]["text"]
+    assert len(payloads) == 1
+    payload = payloads[0]
+    assert payload["channel"] == "UMGR"
+    assert "Pulse Check digest" in payload["text"]
+    assert "Ada Lovelace" in payload["text"]
+    assert "Bob Babbage" in payload["text"]
+    assert "Need approvals" in payload["text"]
+    assert "⚠️" in payload["text"]
 
 
 def test_send_weekly_digest_respects_window_with_timezone(monkeypatch):
@@ -251,9 +280,15 @@ def test_send_weekly_digest_respects_window_with_timezone(monkeypatch):
     _FAKE_SETTINGS = _basic_settings()
     _enable_employee_directory()
     _enable_checkins_table()
-    _FAKE_EMPLOYEES.append({"employee_name": "Ada", "slack_user_id": "U01"})
+    _FAKE_EMPLOYEES.extend(
+        [
+            {"name": "EMP-MGR", "employee_name": "Grace Manager", "slack_user_id": "UMGR"},
+            {"name": "EMP-ADA", "employee_name": "Ada Lovelace", "reports_to": "EMP-MGR"},
+        ]
+    )
     _FAKE_CHECKINS.append(
         {
+            "employee": "EMP-ADA",
             "employee_name": "Ada Lovelace",
             "goal": "Grow pipeline",
             "progress_reported": 80,
@@ -278,6 +313,7 @@ def test_send_weekly_digest_respects_window_with_timezone(monkeypatch):
     sent = digests.send_weekly_digest(now=inside_window)
     assert sent is True
     assert payloads
+    assert payloads[0]["channel"] == "UMGR"
 
 
 def test_send_weekly_digest_handles_missing_checkins(monkeypatch):
@@ -285,7 +321,7 @@ def test_send_weekly_digest_handles_missing_checkins(monkeypatch):
     _FAKE_SETTINGS = _basic_settings()
     _enable_employee_directory()
     _enable_checkins_table()
-    _FAKE_EMPLOYEES.append({"employee_name": "Ada", "slack_user_id": "U01"})
+    _FAKE_EMPLOYEES.append({"name": "EMP-ADA", "employee_name": "Ada", "slack_user_id": "U01"})
 
     monkeypatch.setattr(notifications, "post_to_slack", lambda *args, **kwargs: None)
 
@@ -298,9 +334,15 @@ def test_send_weekly_digest_skips_outside_window_with_timezone(monkeypatch):
     _FAKE_SETTINGS = _basic_settings()
     _enable_employee_directory()
     _enable_checkins_table()
-    _FAKE_EMPLOYEES.append({"employee_name": "Ada", "slack_user_id": "U01"})
+    _FAKE_EMPLOYEES.extend(
+        [
+            {"name": "EMP-MGR", "employee_name": "Grace Manager", "slack_user_id": "UMGR"},
+            {"name": "EMP-ADA", "employee_name": "Ada Lovelace", "reports_to": "EMP-MGR"},
+        ]
+    )
     _FAKE_CHECKINS.append(
         {
+            "employee": "EMP-ADA",
             "employee_name": "Ada Lovelace",
             "goal": "Grow pipeline",
             "progress_reported": 80,
@@ -319,6 +361,7 @@ def test_send_weekly_digest_skips_outside_window_with_timezone(monkeypatch):
     sent = digests.send_weekly_digest(now=datetime(2024, 1, 8, 9, 30, tzinfo=timezone.utc))
 
     assert sent is False
+    assert not called
 
 
 def test_get_slack_token_uses_decrypted_value():
@@ -346,6 +389,6 @@ def test_get_slack_token_falls_back_on_error():
 
     token = notifications.get_slack_token(settings)
 
-    assert token == "fallback-token
+    assert token == "fallback-token"
 
 


### PR DESCRIPTION
## Summary
- group weekly digests by each manager and deliver per-manager Slack messages
- add an employee directory helper to surface manager relationships alongside Slack IDs
- expand the digest job tests to cover manager routing and aggregated payloads

## Testing
- pytest pulsecheck/pulse_check/test_jobs.py

------
https://chatgpt.com/codex/tasks/task_e_68d81dbb6828832297f52817578469da