### PR TITLE
Adjust weekly prompt to cover previous week

### DIFF
--- a/pulsecheck/pulse_check/prompts.py
+++ b/pulsecheck/pulse_check/prompts.py
@@ -44,7 +44,7 @@ def send_weekly_prompts(now: datetime | None = None) -> bool:
         logger.info("No Slack recipients were found; nothing to send.")
         return False
 
-    week_start, week_end = notifications.get_week_bounds(now)
+    week_start, week_end = notifications.get_week_bounds(now, offset_weeks=-1)
     messages_sent = 0
 
     for recipient in recipients:
@@ -73,5 +73,5 @@ def _compose_prompt(employee_name: str | None, week_start, week_end) -> str:
     friendly_name = employee_name or "there"
     return (
         f"Hi {friendly_name}! It's time for your weekly pulse check.\n"
-        f"Please submit your update for {week_start:%b %d} - {week_end:%b %d}."
+        f"Please submit your update for last week ({week_start:%b %d} - {week_end:%b %d})."
     )

--- a/pulsecheck/pulse_check/test_jobs.py
+++ b/pulsecheck/pulse_check/test_jobs.py
@@ -145,6 +145,11 @@ def test_send_weekly_prompts_respects_window_with_timezone(monkeypatch):
     assert sent is True
     assert payloads
 
+    prior_week_start, prior_week_end = notifications.get_week_bounds(inside_window, offset_weeks=-1)
+    expected_range = f"{prior_week_start:%b %d} - {prior_week_end:%b %d}"
+    message = payloads[-1]["text"]
+    assert f"last week ({expected_range})" in message
+
 
 def test_should_run_now_handles_timezone_awareness():
     settings = _basic_settings()
@@ -346,6 +351,6 @@ def test_get_slack_token_falls_back_on_error():
 
     token = notifications.get_slack_token(settings)
 
-    assert token == "fallback-token
+    assert token == "fallback-token"
 
 


### PR DESCRIPTION
## Summary
- update weekly prompt scheduling to request updates for the week that just ended
- refresh the prompt text so it explicitly references last week and its date range
- extend scheduler tests to verify the prior-week messaging and fix a broken assertion

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_68d81dbbeb6483228a6a07bf3ebdf479